### PR TITLE
Add transform hook

### DIFF
--- a/docs/api/bun.md
+++ b/docs/api/bun.md
@@ -69,6 +69,7 @@ The configuration object accepts the following optional options:
 - `cacheFolder`: The location to cache optimized images to. Can be set to either a string path or `no_cache` to not cache to disk.
 - `allowlistedOrigins`: List of allowed remote origins. Defaults to none and can also be set to all (`['*']`).
 - `getImgParams`: Provide a custom function to retrieve the image parameters from the request.
+- `transform`: Provide a custom function to add transformation steps.
 - `getImgSource`: Provide a function to map the `src` image parameter to an image source image. This is useful if you have several locations for hosted images and want provide a custom mapper. Read more about the default `getImgSource` function below.
 
 #### headers: HeadersInit
@@ -127,6 +128,82 @@ type GetImgParams = (
 A function that takes the `Request` object and returns an `ImgParams` object or a `Response` object. If it returns a `Response` object, the response is returned as-is. Otherwise, the returned image parameters is used to optimize the image.
 
 The default implementation retrieves the w (width), h (height), fit, format values from the search parameters of the request and you probably don't need to override the default `getImgParams` function used if no `getImgParams` function is provided. However, for more flexibility, you can implement your own logic to determine the image parameters.
+
+#### transform: Function
+
+```typescript
+type TransformArgs = {
+  params: ImgParams;
+  pipeline: sharp.Sharp;
+};
+
+type Transform = (
+  args: TransformArgs
+) => Promise<void | Response> | void | Response;
+```
+
+A function that takes a sharp instance `pipeline` and a `params` returned by `getImgParams`.
+
+The default implementation has no effect. To have more flexibiliy, you can implement your own transform steps here.
+
+##### Example for a custom `transform` function that colorize png or svg image:
+
+```typescript
+import { TransformArgs, Transform } from "openimg/bun";
+
+export function transform({ request, params, pipeline }: TransformArgs): Transform {
+  const infoPromise = new Promise((resolve) => {
+    pipeline.on('info', (info) => {
+      resolve(info);
+    });
+  });
+  const outputImgInfo = await infoPromise;
+
+  const url = new URL(request.url);
+  const colorize = url.searchParams.get('colorize') || undefined;
+
+  if (colorize) {
+    if (!['white', 'black'].includes(colorize)) {
+      return new Response(null, {
+        status: 400,
+        statusText: 'Search param "colorize" must be either "white" or "black" or unset',
+      });
+    }
+
+    if (!['png', 'svg'].includes(outputImgInfo.format)) {
+      return new Response(null, {
+        status: 400,
+        statusText: 'Colorize is only supported for PNG and SVG images',
+      });
+    }
+
+    if (outputImgInfo.format === 'svg') {
+      // Convert SVG to PNG before colorizing
+      pipeline.png();
+    }
+
+    switch (colorize) {
+      case 'white':
+        pipeline.grayscale().modulate({
+          brightness: 100,
+          saturation: 0,
+        });
+        break;
+      case 'black':
+        pipeline.grayscale().modulate({
+          brightness: 0,
+          saturation: 0,
+        });
+        break;
+      default:
+        return new Response(null, {
+          status: 400,
+          statusText: 'Unhandled colorize value',
+        });
+    }
+  }
+}
+```
 
 #### getImgSource: Function
 

--- a/packages/core/src/bun.ts
+++ b/packages/core/src/bun.ts
@@ -4,6 +4,8 @@ export type {
   Format,
   GetImgParamsArgs,
   GetImgParams,
+  TransformArgs,
+  Transform,
   GetImgSourceArgs,
   GetImgSource,
   ImgParams,

--- a/packages/core/src/bun/index.ts
+++ b/packages/core/src/bun/index.ts
@@ -129,6 +129,13 @@ export async function getImgResponse(request: Request, config: Config = {}) {
       pipeline.resize(params.width, params.height, { fit: params.fit });
     }
 
+    if (config.transform) {
+      const transformRes = await config.transform({ request,pipeline, params });
+      if (transformRes instanceof Response) {
+        return transformRes;
+      }
+    }
+
     const infoPromise = new Promise<sharp.OutputInfo>((resolve) => {
       pipeline.on("info", (info) => {
         resolve(info);

--- a/packages/core/src/bun/index.ts
+++ b/packages/core/src/bun/index.ts
@@ -130,7 +130,7 @@ export async function getImgResponse(request: Request, config: Config = {}) {
     }
 
     if (config.transform) {
-      const transformRes = await config.transform({ request,pipeline, params });
+      const transformRes = await config.transform({ request, pipeline, params });
       if (transformRes instanceof Response) {
         return transformRes;
       }

--- a/packages/core/src/node.ts
+++ b/packages/core/src/node.ts
@@ -4,6 +4,8 @@ export type {
   Format,
   GetImgParamsArgs,
   GetImgParams,
+  TransformArgs,
+  Transform,
   GetImgSourceArgs,
   GetImgSource,
   ImgParams,

--- a/packages/core/src/node/index.ts
+++ b/packages/core/src/node/index.ts
@@ -129,6 +129,13 @@ export async function getImgResponse(request: Request, config: Config = {}) {
       pipeline.resize(params.width, params.height, { fit: params.fit });
     }
 
+    if (config.transform) {
+      const transformRes = await config.transform({ request, pipeline, params });
+      if (transformRes instanceof Response) {
+        return transformRes;
+      }
+    }
+
     const infoPromise = new Promise<sharp.OutputInfo>((resolve) => {
       pipeline.on("info", (info) => {
         resolve(info);

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { ReadStream } from "node:fs";
 import { Readable } from "node:stream";
+import sharp from "sharp";
 
 const FORMATS = ["webp", "avif", "png", "jpeg", "jpg"] as const;
 export type Format = (typeof FORMATS)[number];
@@ -81,6 +82,21 @@ export type GetImgSource = (
   args: GetImgSourceArgs
 ) => Promise<ImgSource | Response> | ImgSource | Response;
 
+export type TransformArgs = {
+  request: Request;
+  params: ImgParams;
+  pipeline: sharp.Sharp;
+};
+
+/**
+ * Called to transform the image pipeline.
+ * The default implementation does nothing.
+ * Implement this function to customize the image transformation logic.
+ */
+export type Transform = (
+  args: TransformArgs
+) => Promise<void | Response> | void | Response;
+
 /**
  * Configuration values for the getImgResponse function.
  * - headers: Headers to be added to the response. Note that no caching headers will be added automatically.
@@ -95,6 +111,7 @@ export type Config = {
   headers?: HeadersInit;
   allowlistedOrigins?: string[]; // default: []
   getImgParams?: GetImgParams;
+  transform?: Transform;
   getImgSource?: GetImgSource;
   cacheFolder?: string | "no_cache"; // default: "./data/images"
 };


### PR DESCRIPTION
_Resolve: https://github.com/andrelandgraf/openimg/issues/6_

## Description

Here we add a transform hook that allow user to handle custom transformations before cache.

## Usage: 

See the `node.md` docs in the PR to understand and have an example.

## Possible improvements: 

### PR improvement:

- [ ] Add tests to be sure `transform` hook is executed.

### Global improvement that would be nice:

Dynamically type `getImgParams` to retrieve custom parameters returned from `getImgParams()` in the `transform` method inputs.