### PR TITLE
Prevent back background around image when resize with contains

### DIFF
--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -338,7 +338,13 @@ export function getDefaultSharpPipeline(params: ImgParams) {
   }
 
   if (params.width && params.height) {
-    pipeline.resize(params.width, params.height, { fit: params.fit });
+    pipeline.resize(params.width, params.height, {
+      fit: params.fit,
+      // Set a transparent background to prevent a black background from appearing around the original image
+      // when it is resized using the “contain” fit property.
+      // The final result is much better, especially when the original image is a PNG without a background.
+      background: { r: 0, g: 0, b: 0, alpha: 0 },
+    });
   }
   return pipeline;
 }


### PR DESCRIPTION
By default, [Sharp defines a black background when resizing](https://sharp.pixelplumbing.com/api-resize/):
<img width="1636" height="365" alt="Screenshot 2025-08-23 at 14 19 29" src="https://github.com/user-attachments/assets/530e4d30-caf8-4783-ab1a-975e29c3f4f4" />

When you call `?width=300&height=300&fit=contains` (resize method is executed), it looks like this:
<img width="1090" height="381" alt="Frame 1" src="https://github.com/user-attachments/assets/3814958a-d6fd-4584-b591-b751f5791fc2" />

As you can see in the first image, when we use a PNG with no background as the source image, the result is not very appealing.

I think it would be better to use a transparent background.

Maybe we could add a parameter to Openimg to choose the background if you prefer? _I don't know how to do that in your code._