### PR TITLE
fix SSR hook errors by using optional React peer deps

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,12 +40,18 @@
     "@types/bun": "latest",
     "thumbhash": "^0.1.1"
   },
-  "optionalDependencies": {
-    "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
-  },
   "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0",
     "sharp": "^0.34.2"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
   },
   "files": [
     "dist",

--- a/tests/react/index.test.tsx
+++ b/tests/react/index.test.tsx
@@ -1,5 +1,6 @@
 import { test, expect } from "bun:test";
 import { screen, render } from "@testing-library/react";
+import { resolve } from "node:path";
 import {
   Img,
   OpenImgContextProvider,
@@ -12,6 +13,22 @@ test("renders without errors when required props are provided", () => {
   render(<Img src="/cat.png" width={800} height={800} alt="A cute cat" />);
   const imgElement = screen.getByAltText("A cute cat");
   expect(imgElement).toBeInTheDocument();
+});
+
+test("renders on server without throwing hook errors", () => {
+  const command =
+    "import React from 'react'; " +
+    "import { renderToString } from 'react-dom/server'; " +
+    "import { Img } from './packages/core/src/react/index.tsx'; " +
+    "const html = renderToString(React.createElement(Img, { src: '/cat.png', width: 800, height: 800, alt: 'SSR cat' })); " +
+    "if (!html.includes('<img')) throw new Error('SSR output missing img element');";
+  const result = Bun.spawnSync(["bun", "--eval", command], {
+    cwd: resolve(process.cwd(), "../.."),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  expect(result.exitCode).toBe(0);
 });
 
 test("applies additional attributes to the <img> tag", () => {


### PR DESCRIPTION
## Summary
- move `react` and `react-dom` from `optionalDependencies` to `peerDependencies`
- mark both peers as optional via `peerDependenciesMeta` so backend-only users are not forced to install React
- add a React SSR regression test that renders `Img` server-side in an isolated process and asserts successful rendering

## Test plan
- [x] `bun run test:react`
- [x] `cd tests/react && bun run typecheck`
- [x] `bun run typecheck:packages`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging metadata and a new test only; no runtime logic changes, with limited risk beyond potential install/peer-resolution differences in some package managers.
> 
> **Overview**
> Fixes packaging for the React integration by moving `react` and `react-dom` from `optionalDependencies` to **optional** `peerDependencies` via `peerDependenciesMeta`, avoiding forced installs for backend-only consumers while keeping peer semantics.
> 
> Adds a regression test that runs `renderToString` in an isolated Bun process to ensure `<Img>` can server-render without throwing hook-related errors and produces an `<img>` in the output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b0e4b1b63cdfc4c98e701d05e391bfee8005910. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->